### PR TITLE
Expand tests, moving to clearer business language

### DIFF
--- a/packages/hardhat/contracts/ToKanBan.sol
+++ b/packages/hardhat/contracts/ToKanBan.sol
@@ -20,12 +20,12 @@ contract ToKanBan{
 
     //task log would record all the task within a Project/contract
     mapping(uint => task) public taskLog;
-    
+
     //structure of each task which would need to be requested by Raider and approved by PM
     struct task{
         //task details
         string details; //describing the details of the task
-        uint funds; //funds allocated to the task 
+        uint funds; //funds allocated to the task
 
         //raider details
         address payable[] requests;
@@ -37,7 +37,8 @@ contract ToKanBan{
 
     // Modfier restricting access to PM
     modifier onlyPM(){
-        require(pm == msg.sender,"Only the ");
+        require(pm != address(0), "This function requires a PM to have been set");
+        require(pm == msg.sender, "Only the PM can call this function");
         _;
     }
 
@@ -45,8 +46,8 @@ contract ToKanBan{
     function setPM(address _pm) public {
         pm = _pm;
     }
-        
-    //Submitting a task 
+
+    //Submitting a task
     function submitTask(uint _funds,string memory _details) public payable onlyPM{
         require(_funds == msg.value, "Funds do not match");
         uint id = _taskIds.current();
@@ -66,7 +67,7 @@ contract ToKanBan{
         uint requestId = taskLog[_id].requests.length;
         emit taskRequested(_id, msg.sender, requestId);
     }
-    
+
     //View Raider who have requested a Task
     function viewRequests(uint _taskid, uint _requestId) view public returns(address, uint){
         return (taskLog[_taskid].requests[_requestId], taskLog[_taskid].funds);
@@ -78,20 +79,20 @@ contract ToKanBan{
         taskLog[_taskid].assigned=true;
         emit assigned(_taskid,taskLog[_taskid].requests[_requestId]);
     }
-    
+
     //task sent for review by PM by Raider
     function taskForReview(uint _taskid) public{
-        require((taskLog[_taskid].raider==msg.sender || pm == msg.sender), "Dont have the access to send the task for review"); 
+        require((taskLog[_taskid].raider==msg.sender || pm == msg.sender), "Dont have the access to send the task for review");
         taskLog[_taskid].reviewed=true;
         emit taskForReviewed(_taskid);
     }
-    
+
     //task reviewed and not accepted
     function taskReviewRevoked(uint _taskid) public onlyPM{
         taskLog[_taskid].reviewed=false;
         emit taskReviewRevoke(_taskid);
     }
-    
+
     //task marked complete by PM
     function taskComplete(uint _taskid) public onlyPM{
         require(taskLog[_taskid].reviewed==true,"The task has not been sent for review");
@@ -104,13 +105,13 @@ contract ToKanBan{
         taskLog[_taskid].closed=true;
         emit taskCompleted(_taskid, funds);
     }
-    
+
      //the contract can receive ether from external contract
     function payContract() external payable {
     }
-    
+
     //checking the balance of the contract
     function getBalance() view public returns(uint){
         return address(this).balance;
     }
-}    
+}

--- a/packages/hardhat/package-lock.json
+++ b/packages/hardhat/package-lock.json
@@ -1362,6 +1362,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -4,6 +4,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "ethereum-waffle": "^3.3.0",
     "ethers": "^5.2.0",
     "hardhat": "^2.3.0"

--- a/packages/hardhat/test/tokanban-test.js
+++ b/packages/hardhat/test/tokanban-test.js
@@ -1,10 +1,20 @@
-const { expect } = require("chai");
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
 const { ethers } = require("hardhat");
 const { BigNumber } = require("@ethersproject/bignumber");
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+// Helpers to improve the test language
+const given = (description, fun) => describe("Given " + description, fun);
+const then = (description, fun) => it(description, fun);
+
 
 describe("ToKanBan", function () {
   before(async function () {
     this.Kanban = await ethers.getContractFactory("ToKanBan");
+    this.accounts = await ethers.getSigners();
   });
 
   beforeEach(async function () {
@@ -12,32 +22,88 @@ describe("ToKanBan", function () {
     await this.kanban.deployed();
   });
 
-  it("Should set PM", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
+  given("no PM has been set", async function () {
+    then("setPM succeeds", async function () {
+      await this.kanban.setPM(this.accounts[0].address);
+      const pm = await this.kanban.pm();
 
-    const pm = await this.kanban.pm();
+      expect(pm).equals(this.accounts[0].address);
+    });
 
-    expect(pm).equals(accounts[0].address);
+    then("submitTask fails", async function () {
+      await expect(
+        this.kanban.submitTask(1000, "Update the README")
+      ).to.be.rejectedWith("This function requires a PM to have been set");
+    });
+
+    then("assignTaskToRaider fails", async function () {
+      await expect(
+        this.kanban.assignTaskToRaider(1, 1)
+      ).to.be.rejectedWith("This function requires a PM to have been set");
+    });
+
+    then("taskReviewRevoked fails", async function () {
+      await expect(
+        this.kanban.taskReviewRevoked(1)
+      ).to.be.rejectedWith("This function requires a PM to have been set");
+    });
+
+    then("taskComplete fails", async function () {
+      await expect(
+        this.kanban.taskComplete(1)
+      ).to.be.rejectedWith("This function requires a PM to have been set");
+    });
   });
 
-  it("Should submit tasks", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
 
-    const value = ethers.utils.parseEther("1");
-    const details = "A sample task";
-    await this.kanban.submitTask(value, details, { value: value });
+  given("a PM has been set", async function () {
 
-    const task = await this.kanban.taskLog(0);
+    beforeEach(async function() {
+      await this.kanban.setPM(this.accounts[0].address);
+    })
 
-    expect(task.funds.value).equals(value.value);
-    expect(task.details).equals(details);
+    then("submitTask succeeds", async function () {
+      const value = ethers.utils.parseEther("1");
+      const details = "A sample task";
+      await this.kanban.submitTask(value, details, { value: value });
+
+      const task = await this.kanban.taskLog(0);
+
+      expect(task.funds.value).equals(value.value);
+      expect(task.details).equals(details);
+    });
+
+    then("taskComplete succeeds", async function () {
+      const value = ethers.utils.parseEther("1");
+      const details = "A sample task";
+      await this.kanban.submitTask(value, details, { value: value });
+      await this.kanban.requestTask(0);
+      await this.kanban.assignTaskToRaider(0, 0);
+      await this.kanban.taskForReview(0);
+      await this.kanban.taskComplete(0);
+
+      const task = await this.kanban.taskLog(0);
+
+      expect(task.closed).to.be.true;
+      expect(task.funds.toHexString()).equals(BigNumber.from("0").toHexString());
+    });
+
+    then("assignTaskToRaider succeeds", async function () {
+      const value = ethers.utils.parseEther("1");
+      const details = "A sample task";
+      await this.kanban.submitTask(value, details, { value: value });
+      await this.kanban.requestTask(0);
+      await this.kanban.assignTaskToRaider(0, 0);
+
+      const task = await this.kanban.taskLog(0);
+      expect(task.raider).equals(this.accounts[0].address);
+      expect(task.assigned).to.be.true;
+    });
+
   });
 
   it("Should request tasks", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
+    await this.kanban.setPM(this.accounts[0].address);
 
     const value = ethers.utils.parseEther("1");
     const details = "A sample task";
@@ -45,27 +111,11 @@ describe("ToKanBan", function () {
     await this.kanban.requestTask(0);
 
     const raider = await this.kanban.viewRequests(0, 0);
-    expect(raider[0]).equals(accounts[0].address);
-  });
-
-  it("Should assign task to raider", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
-
-    const value = ethers.utils.parseEther("1");
-    const details = "A sample task";
-    await this.kanban.submitTask(value, details, { value: value });
-    await this.kanban.requestTask(0);
-    await this.kanban.assignTaskToRaider(0, 0);
-
-    const task = await this.kanban.taskLog(0);
-    expect(task.raider).equals(accounts[0].address);
-    expect(task.assigned).to.be.true;
+    expect(raider[0]).equals(this.accounts[0].address);
   });
 
   it("Should send tasks for review", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
+    await this.kanban.setPM(this.accounts[0].address);
 
     const value = ethers.utils.parseEther("1");
     const details = "A sample task";
@@ -78,21 +128,4 @@ describe("ToKanBan", function () {
     expect(task.reviewed).to.be.true;
   });
 
-  it("Should complete tasks", async function () {
-    const accounts = await ethers.getSigners();
-    await this.kanban.setPM(accounts[0].address);
-
-    const value = ethers.utils.parseEther("1");
-    const details = "A sample task";
-    await this.kanban.submitTask(value, details, { value: value });
-    await this.kanban.requestTask(0);
-    await this.kanban.assignTaskToRaider(0, 0);
-    await this.kanban.taskForReview(0);
-    await this.kanban.taskComplete(0);
-
-    const task = await this.kanban.taskLog(0);
-
-    expect(task.closed).to.be.true;
-    expect(task.funds.toHexString()).equals(BigNumber.from("0").toHexString());
-  });
 });

--- a/packages/hardhat/test/tokanban-test.js
+++ b/packages/hardhat/test/tokanban-test.js
@@ -23,35 +23,35 @@ describe("ToKanBan", function () {
   });
 
   given("no PM has been set", async function () {
-    then("setPM succeeds", async function () {
+    then("a PM can be set by anybody", async function () {
       await this.kanban.setPM(this.accounts[0].address);
       const pm = await this.kanban.pm();
 
       expect(pm).equals(this.accounts[0].address);
     });
 
-    then("submitTask fails", async function () {
+    then("tasks can't be submitted", async function () {
       await expect(
         this.kanban.submitTask(1000, "Update the README")
       ).to.be.rejectedWith("This function requires a PM to have been set");
     });
 
-    then("assignTaskToRaider fails", async function () {
-      await expect(
-        this.kanban.assignTaskToRaider(1, 1)
-      ).to.be.rejectedWith("This function requires a PM to have been set");
+    then("tasks can't be assigned to Raiders", async function () {
+      await expect(this.kanban.assignTaskToRaider(1, 1)).to.be.rejectedWith(
+        "This function requires a PM to have been set"
+      );
     });
 
-    then("taskReviewRevoked fails", async function () {
-      await expect(
-        this.kanban.taskReviewRevoked(1)
-      ).to.be.rejectedWith("This function requires a PM to have been set");
+    then("task reviews can't be revoked", async function () {
+      await expect(this.kanban.taskReviewRevoked(1)).to.be.rejectedWith(
+        "This function requires a PM to have been set"
+      );
     });
 
-    then("taskComplete fails", async function () {
-      await expect(
-        this.kanban.taskComplete(1)
-      ).to.be.rejectedWith("This function requires a PM to have been set");
+    then("tasks can't be marked as complete", async function () {
+      await expect(this.kanban.taskComplete(1)).to.be.rejectedWith(
+        "This function requires a PM to have been set"
+      );
     });
   });
 
@@ -62,7 +62,7 @@ describe("ToKanBan", function () {
       await this.kanban.setPM(this.accounts[0].address);
     })
 
-    then("submitTask succeeds", async function () {
+    then("tasks can be submitted", async function () {
       const value = ethers.utils.parseEther("1");
       const details = "A sample task";
       await this.kanban.submitTask(value, details, { value: value });
@@ -73,7 +73,7 @@ describe("ToKanBan", function () {
       expect(task.details).equals(details);
     });
 
-    then("taskComplete succeeds", async function () {
+    then("tasks can be marked as complete", async function () {
       const value = ethers.utils.parseEther("1");
       const details = "A sample task";
       await this.kanban.submitTask(value, details, { value: value });
@@ -85,10 +85,12 @@ describe("ToKanBan", function () {
       const task = await this.kanban.taskLog(0);
 
       expect(task.closed).to.be.true;
-      expect(task.funds.toHexString()).equals(BigNumber.from("0").toHexString());
+      expect(task.funds.toHexString()).equals(
+        BigNumber.from("0").toHexString()
+      );
     });
 
-    then("assignTaskToRaider succeeds", async function () {
+    then("tasks can be assigned to a raider", async function () {
       const value = ethers.utils.parseEther("1");
       const details = "A sample task";
       await this.kanban.submitTask(value, details, { value: value });


### PR DESCRIPTION
This aims to help give a framework for deciding what behaviour is desired, and what is merely accidental. Ideally this language can be hoisted out of the test suite and used at the project level to communicate functinality. 

Now the test run looks like this: 
```  
ToKanBan
    ✓ Should request tasks (80ms)
    ✓ Should send tasks for review (91ms)
    Given no PM has been set
      ✓ a PM can be set by anybody
      ✓ tasks can't be submitted
      ✓ tasks can't be assigned to Raiders
      ✓ task reviews can't be revoked
      ✓ tasks can't be marked as complete
    Given a PM has been set
      ✓ tasks can be submitted
      ✓ tasks can be marked as complete (62ms)
      ✓ tasks can be assigned to a raider (39ms)
```

Which starts to give some more obvious naming to how the different functions work. 

I've also added an extra error case to the .sol contract, to differentiate from a PM being unset vs being unauthorised. 

(Sorry about the large commit, I was doing lots of exploration and it's been a while since I've used mocha. Things got a bit messy and I wasn't able to split the commits up cleanly. I suggest you look at the final files to see what's changed.).  