### PR TITLE
Show the total funds for a board

### DIFF
--- a/packages/next-app/data/queries.ts
+++ b/packages/next-app/data/queries.ts
@@ -20,6 +20,7 @@ export const KANBAN_BOARD_BY_ID = (id) => {
         id
         address
         title
+        funds
         description
         tasks {
           id

--- a/packages/next-app/pages/[kanbanId]/index.tsx
+++ b/packages/next-app/pages/[kanbanId]/index.tsx
@@ -25,9 +25,13 @@ export default function Kanban() {
     <div>
       <Layout>
         <div className="p-3">
-          <div className="ml-5 text-2xl font-light">
-            {kanban && kanban.title}
-          </div>
+            {kanban
+              ? <div className="mx-5 text-2xl font-light flex justify-between">
+                  <div>{kanban.title}</div>
+                  <div>Total Funds: {kanban.funds}<span className="text-base">ETH</span></div>
+                </div>
+              : <div className="mx-5 text-2xl font-light">Board loading...</div>
+          }
           <div className="flex mt-6">
             <div className="w-1/3 px-6">
               <div className="text-gray-500">New Tasks</div>


### PR DESCRIPTION
I'm pretty sure this doesn't actually connect to anything yet, and we haven't worked out the exact model for funding boards / tasks.

But this is a first step and it should work whenever we update the board funds.